### PR TITLE
feat: install into *all* Google Chrome browsers

### DIFF
--- a/download_test.go
+++ b/download_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"io"
 	"io/ioutil"
 	"log"
@@ -20,6 +19,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 var opened bool
@@ -177,7 +178,7 @@ func TestDownloadLatest(t *testing.T) {
 				if info, err := os.Stat(targetName); err != nil {
 					t.Fatalf("missing file: %v", err)
 				} else if fmt.Sprintf("%#o", info.Mode().Perm()) != "0755" {
-					t.Fatalf("wrong file permission: %v", err)
+					t.Fatalf("wrong file permission (%#o != 0755): %v", info.Mode().Perm(), err)
 				}
 
 				if buf, err := ioutil.ReadFile(targetName); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.15
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-version v1.6.0
+	github.com/stretchr/testify v1.8.2 // indirect
 	golang.org/x/sys v0.5.0
 )

--- a/manifest.go
+++ b/manifest.go
@@ -5,6 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//go:build !darwin && !windows
 // +build !darwin,!windows
 
 package host
@@ -16,19 +17,28 @@ import (
 	"path/filepath"
 )
 
-// getTargetName returns an absolute path to native messaging host manifest
-// location for Linux.
+// getTargetName returns absolute paths to the native messaging host manifest
+// locations for Linux.
 //
 // See https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location-nix
-func (h *Host) getTargetName() string {
-	target := "/etc/opt/chrome/native-messaging-hosts"
-
+func (h *Host) getTargetNames() ([]string, error) {
+	targets := []string{}
 	if os.Getuid() != 0 {
 		homeDir, _ := os.UserHomeDir()
-		target = homeDir + "/.config/google-chrome/NativeMessagingHosts"
+		matches, err := filepath.Glob(homeDir + "/.config/google-chrome*/NativeMessagingHosts")
+		if err != nil {
+			return nil, err
+		}
+		for _, s := range matches {
+			target := filepath.Join(s, h.AppName+".json")
+			targets = append(targets, target)
+		}
+	} else {
+		target := filepath.Join("/etc/opt/chrome/native-messaging-hosts", h.AppName+".json")
+		targets = append(targets, target)
 	}
 
-	return filepath.Join(target, h.AppName+".json")
+	return targets, nil
 }
 
 // Install creates native-messaging manifest file on appropriate location. It
@@ -37,17 +47,22 @@ func (h *Host) getTargetName() string {
 // See https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location-nix
 func (h *Host) Install() error {
 	manifest, _ := json.MarshalIndent(h, "", "  ")
-	targetName := h.getTargetName()
-
-	if err := osMkdirAll(filepath.Dir(targetName), 0755); err != nil {
+	targetNames, err := h.getTargetNames()
+	if err != nil {
 		return err
 	}
 
-	if err := ioutilWriteFile(targetName, manifest, 0644); err != nil {
-		return err
-	}
+	for _, targetName := range targetNames {
+		if err := osMkdirAll(filepath.Dir(targetName), 0755); err != nil {
+			return err
+		}
 
-	log.Printf("Installed: %s", targetName)
+		if err := ioutilWriteFile(targetName, manifest, 0644); err != nil {
+			return err
+		}
+
+		log.Printf("Installed: %s", targetName)
+	}
 	return nil
 }
 
@@ -55,24 +70,30 @@ func (h *Host) Install() error {
 //
 // See https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location-nix
 func (h *Host) Uninstall() {
-	targetName := h.getTargetName()
+	targetNames, err := h.getTargetNames()
 
-	if err := os.Remove(targetName); err != nil {
-		// It might never have been installed.
-		log.Print(err)
+	if err != nil {
+		return
 	}
 
-	if err := os.Remove(h.ExecName); err != nil {
-		// It might be locked by current process.
-		log.Print(err)
-	}
+	for _, targetName := range targetNames {
+		if err := os.Remove(targetName); err != nil {
+			// It might never have been installed.
+			log.Print(err)
+		}
 
-	if err := os.Remove(h.ExecName + ".chk"); err != nil {
-		// It might not exist.
-		log.Print(err)
-	}
+		if err := os.Remove(h.ExecName); err != nil {
+			// It might be locked by current process.
+			log.Print(err)
+		}
 
-	log.Printf("Uninstalled: %s", targetName)
+		if err := os.Remove(h.ExecName + ".chk"); err != nil {
+			// It might not exist.
+			log.Print(err)
+		}
+
+		log.Printf("Uninstalled: %s", targetName)
+	}
 
 	// Exit gracefully.
 	runtimeGoexit()

--- a/manifest_windows.go
+++ b/manifest_windows.go
@@ -4,16 +4,43 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//go:build windows
 
 package host
 
 import (
 	"encoding/json"
-	"golang.org/x/sys/windows/registry"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
 )
+
+func (h *Host) getTargetNames() ([]string, error) {
+	targets := []string{}
+	registryKey := `SOFTWARE\Google`
+	var access uint32 = registry.QUERY_VALUE | registry.ENUMERATE_SUB_KEYS
+	regKey, err := registry.OpenKey(registry.CURRENT_USER, registryKey, access)
+	defer func() {
+		if err := regKey.Close(); err != nil {
+		}
+	}()
+
+	keyNames, err := regKey.ReadSubKeyNames(0)
+	if err != nil {
+		return nil, err
+	} else {
+		for _, keyName := range keyNames {
+			if strings.HasPrefix(keyName, "Chrome") {
+				fullKey := registryKey + `\` + keyName
+				targets = append(targets, fullKey)
+			}
+		}
+	}
+	return targets, nil
+}
 
 // Install creates native-messaging manifest file on appropriate location and
 // add an entry in windows registry. It will return error when it come across
@@ -22,26 +49,34 @@ import (
 // See https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location
 func (h *Host) Install() error {
 	manifest, _ := json.MarshalIndent(h, "", "  ")
-	registryName := `Software\Google\Chrome\NativeMessagingHosts\` + h.AppName
-	targetName := filepath.Join(filepath.Dir(h.ExecName), h.AppName+".json")
-
-	if err := ioutilWriteFile(targetName, manifest, 0644); err != nil {
-		return err
-	}
-
-	// CreateKey creates a key named path under open key k. CreateKey returns the
-	// new key and a boolean flag that reports whether the key already existed.
-	key, _, err := registry.CreateKey(registry.CURRENT_USER, registryName, registry.SET_VALUE)
+	registryNames, err := h.getTargetNames()
 	if err != nil {
 		return err
 	}
-	defer key.Close()
+	for _, keyName := range registryNames {
+		registryName := keyName + `\NativeMessagingHosts\` + h.AppName
+		targetName := filepath.Join(filepath.Dir(h.ExecName), h.AppName+".json")
 
-	if err := key.SetStringValue("", targetName); err != nil {
-		return err
+		if err := ioutilWriteFile(targetName, manifest, 0644); err != nil {
+			return err
+		}
+
+		// CreateKey creates a key named path under open key k. CreateKey returns the
+		// new key and a boolean flag that reports whether the key already existed.
+		key, _, err := registry.CreateKey(registry.CURRENT_USER, registryName, registry.SET_VALUE)
+		if err != nil {
+			log.Printf(`Error installing: HKCU\%s: %v`, registryName, err)
+		} else {
+			defer key.Close()
+
+			if err := key.SetStringValue("", targetName); err != nil {
+				log.Printf(`Error installing: HKCU\%s: %v`, registryName, err)
+			} else {
+
+				log.Printf(`Installed: HKCU\%s`, registryName)
+			}
+		}
 	}
-
-	log.Printf(`Installed: HKCU\%s`, registryName)
 	return nil
 }
 
@@ -50,38 +85,46 @@ func (h *Host) Install() error {
 //
 // See https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location
 func (h *Host) Uninstall() {
-	registryName := `Software\Google\Chrome\NativeMessagingHosts\` + h.AppName
-	targetName := filepath.Join(filepath.Dir(h.ExecName), h.AppName+".json")
-
-	key, err := registry.OpenKey(registry.CURRENT_USER, registryName, registry.SET_VALUE)
+	registryNames, err := h.getTargetNames()
 	if err != nil {
-		// Unable to open windows registry.
-		log.Print(err)
-	}
-	defer key.Close()
-
-	if err := key.DeleteValue(""); err != nil {
-		// It might never have been installed.
-		log.Print(err)
+		return
 	}
 
-	if err := os.Remove(targetName); err != nil {
-		// It might never have been installed.
-		log.Print(err)
+	for _, keyName := range registryNames {
+		registryName := keyName + `\NativeMessagingHosts\` + h.AppName
+
+		targetName := filepath.Join(filepath.Dir(h.ExecName), h.AppName+".json")
+
+		key, err := registry.OpenKey(registry.CURRENT_USER, registryName, registry.SET_VALUE)
+		if err != nil {
+			log.Printf("Error opening %s: %v", registryName, err)
+		} else {
+			defer key.Close()
+
+			if err := key.DeleteValue(""); err != nil {
+				// It might never have been installed.
+				log.Print(err)
+			}
+
+			if err := os.Remove(targetName); err != nil {
+				// It might never have been installed.
+				log.Print(err)
+			}
+
+			if err := os.Remove(h.ExecName); err != nil {
+				// It might be locked by current process.
+				log.Print(err)
+			}
+
+			if err := os.Remove(h.ExecName + ".chk"); err != nil {
+				// It might not exist.
+				log.Print(err)
+			}
+
+			log.Printf(`Uninstalled: HKCU\%s`, registryName)
+		}
+
 	}
-
-	if err := os.Remove(h.ExecName); err != nil {
-		// It might be locked by current process.
-		log.Print(err)
-	}
-
-	if err := os.Remove(h.ExecName + ".chk"); err != nil {
-		// It might not exist.
-		log.Print(err)
-	}
-
-	log.Printf(`Uninstalled: HKCU\%s`, registryName)
-
 	// Exit gracefully.
 	runtimeGoexit()
 }

--- a/manifest_windows_test.go
+++ b/manifest_windows_test.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package host
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManifestTargetName(t *testing.T) {
+	t.Parallel()
+
+	got, err := (&Host{AppName: "app"}).getTargetNames()
+	assert.Nil(t, err)
+	assert.Greater(t, len(got), 0)
+	want := `SOFTWARE\Google\Chrome`
+
+	if diff := cmp.Diff(want, got[0]); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
A user might have one or more of Beta, Canary, Stable installed. 

For Linux, use a glob to find each profile and iterate. 
For Windows, iterate over the registry keys.